### PR TITLE
install and use local nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.4.0",
     "mocha-multi": "^0.7.1",
+    "nodemon": "^1.9.0",
     "parallelshell": "^1.1.1",
     "plato": "^1.5.0",
     "pre-commit": "^1.0.10",


### PR DESCRIPTION
Let's use and manage our own internal `nodemon` instead of relying on an implied global dependency. I couldn't find `nodemon` listed as a depenedency in the [README.md](README.md) either so I'm assuming that's probably an omission (also assuming everyone who's run this )

- installs nodemon
- runs `/node_modules/.bin/nodemon` instead of `nodemon` in the various npm scripts