### PR TITLE
Use the latest middleware from hof.

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,8 @@ app.use(require('hof').middleware());
 // apps
 app.use(require('./apps/my_awesome_form/'));
 
+app.use(require('./middleware/not-found')());
+
 // errors
 app.use(require('./errors/'));
 

--- a/apps/common/translations/en/default.json
+++ b/apps/common/translations/en/default.json
@@ -13,13 +13,21 @@
 		}
 	},
 	"errors": {
+		"404": {
+			"title": "Page not found",
+			"description": "This page does not exist"
+		},
 		"default": {
 			"title": "Sorry, something went wrong",
 			"message": "A server exception occurred. Please try again."
 		},
 		"session": {
 			"title": "Sorry, you'll have to start again",
-			"message": "You haven't entered any details for 20 minutes, so we have cleared your information to keep it secure."
+			"message": "You haven't entered any details for 30 minutes, so we have cleared your information to keep it secure."
+		},
+		"cookies-required": {
+			"title": "Cookies are required to use this service",
+			"message": "Cookies are required in order to use the BRP service.<br /><br /> Please <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">enable cookies</a> and try again. Find out <a href=\"/cookies\">how to we use cookies</a>."
 		}
 	}
 }

--- a/apps/common/translations/src/en/errors.json
+++ b/apps/common/translations/src/en/errors.json
@@ -6,5 +6,13 @@
   "session": {
     "title": "Sorry, you'll have to start again",
     "message": "You haven't entered any details for 20 minutes, so we have cleared your information to keep it secure."
+  },
+  "404": {
+    "title": "Page not found",
+    "description": "This page does not exist"
+  },
+  "cookies-required": {
+    "title": "Cookies are required to use this service",
+    "message": "Cookies are required in order to use the BRP service.<br /><br /> Please <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">enable cookies</a> and try again. Find out <a href=\"/cookies\">how to we use cookies</a>."
   }
 }

--- a/apps/common/views/404.html
+++ b/apps/common/views/404.html
@@ -1,0 +1,11 @@
+{{<layout}}
+
+{{$header}}
+    {{content.title}}
+{{/header}}
+
+{{$content}}
+  <p>{{description}}</p>
+{{/content}}
+
+{{/layout}}

--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -5,7 +5,7 @@
 {{/header}}
 
 {{$content}}
-    <p>{{content.message}}</p>
+    <p>{{{content.message}}}</p>
     <a href="/{{startLink}}" class="button" role="button">Start again</a>
     {{#showStack}}
       <pre>

--- a/errors/index.js
+++ b/errors/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var path = require('path');
 var hof = require('hof');
 var i18n = hof.i18n({
@@ -17,6 +18,12 @@ module.exports = function errorHandler(err, req, res) {
     content.message = i18n.translate('errors.session.message');
   }
 
+  if (err.code === 'NO_COOKIES') {
+    err.status = 403;
+    content.title = i18n.translate('errors.cookies-required.title');
+    content.message = i18n.translate('errors.cookies-required.message');
+  }
+
   err.template = 'error';
   content.title = content.title || i18n.translate('errors.default.title');
   content.message = content.message || i18n.translate('errors.default.message');
@@ -24,7 +31,6 @@ module.exports = function errorHandler(err, req, res) {
   res.statusCode = err.status || 500;
 
   logger.error(err.message || err.error, err);
-
   res.render(err.template, {
     error: err,
     content: content,

--- a/middleware/not-found.js
+++ b/middleware/not-found.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var path = require('path');
+var hof = require('hof');
+var i18n = hof.i18n({
+  path: path.resolve(__dirname, '../apps/common/translations/__lng__/__ns__.json')
+});
+var logger = require('../lib/logger');
+
+module.exports = function notFound() {
+  return function notFoundHandler(req, res) {
+    logger.warn('Cannot find:', req.url);
+
+    res.status(404).render('404', {
+      title: i18n.translate('errors.404.title'),
+      description: i18n.translate('errors.404.description')
+    });
+  };
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.11.3",
-    "hof": "4.0.0",
+    "hof": "5.0.0",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
     "jquery": "^2.1.4",


### PR DESCRIPTION
This changes how we handle cookies slightly.

Previously if cookies were disabled you would be redirected to a cookies-required page.

The latest version of the middleware will return an error in the callback and let you decide how you want to handle the error.

Also added 404 handling.