### PR TITLE
Fixes #36 - use phantomjs-gem version 1.9.8.0 to match the version pr…

### DIFF
--- a/acceptance_tests/Gemfile
+++ b/acceptance_tests/Gemfile
@@ -4,7 +4,7 @@ gem 'cucumber'
 gem 'capybara'
 gem 'rspec'
 gem 'poltergeist'
-gem 'phantomjs', :group => :test
+gem 'phantomjs', '1.9.8.0'
 gem 'show_me_the_cookies'
 gem 'yard-cucumber'
 gem 'selenium-webdriver', '2.45.0'


### PR DESCRIPTION
…einstalled on travis

This is necessary because travis quite often fails to download phantomjs 2.2 from CDN and comes with 1.9.8 preinstalled.

More info here: https://github.com/colszowka/phantomjs-gem/issues/70
and
https://github.com/colszowka/phantomjs-gem/issues/79