### PR TITLE
add fourth param (next) to errorhandler function

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -9,10 +9,9 @@ var config = require('../config');
 var logger = require('../lib/logger');
 
 /*eslint no-unused-vars: 0*/
-module.exports = function errorHandler(err, req, res) {
+module.exports = function errorHandler(err, req, res, next) {
   /*eslint no-unused-vars: 1*/
   var content = {};
-
   if (err.code === 'SESSION_TIMEOUT') {
     content.title = i18n.translate('errors.session.title');
     content.message = i18n.translate('errors.session.message');


### PR DESCRIPTION
Express won't honour error handling middleware unless the function explicitly expects four parameters.
`function (err, req, res, next)`
So the error was not being called and error template not being loaded.
